### PR TITLE
Fix config settings in async join

### DIFF
--- a/denorm/join_async.py
+++ b/denorm/join_async.py
@@ -252,7 +252,7 @@ def enqueue_sql(
 
     if context:
         settings = sql_list(
-            f"coalesce(current_setting({SqlString(f'context.{setting}')}, true), '')"
+            f"coalesce(current_setting({SqlString(setting)}, true), '')"
             for setting in context
         )
         key_query = f"""


### PR DESCRIPTION
I'm thinking that the `context.` prefix is a mistake?  I don't see it getting set that way anywhere.